### PR TITLE
Add DRCOG to list of public data sources

### DIFF
--- a/ruby_03-professional_rails_applications/self_directed_project.markdown
+++ b/ruby_03-professional_rails_applications/self_directed_project.markdown
@@ -56,6 +56,7 @@ a public/non-profit non-partisan source such as:**
 * [United Nations](https://www.undata-api.org/) (3rd party API)
 * [Google's Directory of Public Data](http://www.google.com/publicdata/directory)
 * [OpenColorado](http://data.opencolorado.org/)
+* [Denver Regional Council of Governments](https://drcog.org/services-and-resources/data-maps-and-modeling)
 
 You can, in addition to one of those sources, include commercial APIs like:
 


### PR DESCRIPTION
The Denver Regional Council of Goverments maintains an excellent data portal for public data about the greater Denver area.
