### PR TITLE
Update websockets_workshop.markdown

### DIFF
--- a/ruby_04-apis_and_scalability/websockets_workshop.markdown
+++ b/ruby_04-apis_and_scalability/websockets_workshop.markdown
@@ -438,13 +438,14 @@ The key/value object is useful for keeping track of votes. Let's write a super s
 
 ```js
 // server.js
-function countVotes(votes) {
-  var voteCount = {
+var voteCount = {
     A: 0,
     B: 0,
     C: 0,
     D: 0
-  };
+};
+  
+function countVotes(votes) {
   for (vote in votes) {
     voteCount[votes[vote]]++
   }


### PR DESCRIPTION
When voteCount is instantiated within the countVotes function, it resets all keys to 0 each time it's called.