### PR TITLE
Update intro_to_active_record_in_sinatra.markdown

### DIFF
--- a/ruby_02-web_applications_with_ruby/intro_to_active_record_in_sinatra.markdown
+++ b/ruby_02-web_applications_with_ruby/intro_to_active_record_in_sinatra.markdown
@@ -167,6 +167,7 @@ ActiveRecord::Schema.define(version: 20150217022905) do
     t.integer  "box_office_sales"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "genre_id"
   end
 
   create_table "genres", force: :cascade do |t|


### PR DESCRIPTION
Unless I'm mistaken, the code example only reflects one of the migrations. I think it's supposed to reflect a new genre_id column in the films table too.