### PR TITLE
Update getting_started_with_oauth.md

### DIFF
--- a/ruby_03-professional_rails_applications/getting_started_with_oauth.md
+++ b/ruby_03-professional_rails_applications/getting_started_with_oauth.md
@@ -260,6 +260,7 @@ user information we'd like to save to our new `User` model:
 
 * `name`
 * `screen_name`
+* `uid`
 * `user_id` (by convention, we often save this into a column called `uid`)
 * `oauth_token`
 * `oauth_token_secret`


### PR DESCRIPTION
uid was not included in the user model in the database leading to an error when logging in after we implemented the self.from_omniauth(auth_info) method in the User.rb