### PR TITLE
Add info for a workaround with shoulda-matchers

### DIFF
--- a/ruby_02-web_applications_with_ruby/mix_master/2_implementing_artists.markdown
+++ b/ruby_02-web_applications_with_ruby/mix_master/2_implementing_artists.markdown
@@ -851,6 +851,8 @@ group :development, :test do
 end
 ```
 
+Note: You may need to add `gem 'shoulda-matchers', github: 'thoughtbot/shoulda-matchers'` per [this bug report](https://github.com/thoughtbot/shoulda-matchers/issues/703) if you get a `NoMethodError` when trying to run rspec after bundling.
+
 And `bundle`. Next, we'll configure shoulda matchers to work with RSpec in `rails_helper.rb`:
 
 ```ruby


### PR DESCRIPTION
I had a problem where I kept getting a NoMethodError for Shoulda::Matchers.configure. I found the solution for it and am adding it to this document in case other people experience it.