### PR TITLE
Removes early addition of playlist#show route

### DIFF
--- a/ruby_02-web_applications_with_ruby/mix_master/4_implementing_playlists.markdown
+++ b/ruby_02-web_applications_with_ruby/mix_master/4_implementing_playlists.markdown
@@ -398,7 +398,7 @@ Rails.application.routes.draw do
   end
 
   resources :songs, only: [:show]
-  resources :playlists, only: [:index, :new, :create, :show]
+  resources :playlists, only: [:index, :new, :create]
 end
 ```
 


### PR DESCRIPTION
You added :show to the resources :playlists line before using it, and then specifically mention adding it later so it makes sense to remove it here.