### PR TITLE
Fix "routes" update that breaks other tests

### DIFF
--- a/ruby_02-web_applications_with_ruby/mix_master/3_implementing_songs.markdown
+++ b/ruby_02-web_applications_with_ruby/mix_master/3_implementing_songs.markdown
@@ -299,7 +299,7 @@ What's happening here? We'll, because we've passed in a new object (`@song`) to 
 
 ```ruby
 Rails.application.routes.draw do
-  resources :artists, only: [:index, :new, :create, :show] do 
+  resources :artists do 
     resources :songs, only: [:new, :create]
   end
 end


### PR DESCRIPTION
In addition to adding the :create action to :songs, this code (lines 300-305) removes 3 actions from :artists (:edit, :update, and :destroy), which we need to pass the user_edits_an_artist and user_deletes_an_artist feature tests we created in iteration 2.

See also lines 131-136 of i_3.