### PR TITLE
Changes myShow to reflect the global variable

### DIFF
--- a/ruby_04-apis_and_scalability/js_refactor_tractor.md
+++ b/ruby_04-apis_and_scalability/js_refactor_tractor.md
@@ -226,7 +226,7 @@ Instead, we should consider caching - storing the reference to the object in a v
 
   $myHeader.hide();
   // do some things
-  $myShow.hide();
+  $myHeader.show();
 ```
 
 #### Array Iteration


### PR DESCRIPTION
This is a simple bug fix that changes $myShow.hide(); to become $myHeader.show();