### PR TITLE
removing unneeded  route

### DIFF
--- a/ruby_04-apis_and_scalability/websockets_workshop.markdown
+++ b/ruby_04-apis_and_scalability/websockets_workshop.markdown
@@ -96,9 +96,6 @@ const app = express();
 
 app.use(express.static('public'));
 
-app.get('/', function (req, res){
-  res.sendFile(__dirname + '/public/index.html');
-});
 ```
 
 This will be enough to cover our server's basic behavior,


### PR DESCRIPTION
```
app.get('/', function (req, res){		
  res.sendFile(__dirname + '/public/index.html');		
});
```

describes a subset of 

```
app.use(express.static('public'));
```

I removed the code and the app seems to serve index.html in public folder just fine
