### PR TITLE
Update exploring_apis.markdown

### DIFF
--- a/ruby_02-web_applications_with_ruby/exploring_apis.markdown
+++ b/ruby_02-web_applications_with_ruby/exploring_apis.markdown
@@ -146,7 +146,7 @@ Another thing we can do is use an OpenStruct in order to access the data with do
 
 ```ruby
 data = JSON.parse(response.body, object_class: OpenStruct)
-data.city.name
+data.name
 ```
 
 ### Workshop


### PR DESCRIPTION
if we chain with ".city" it brings nil. 
but if we say ".name" it brings back Denver.