### PR TITLE
Add actual output from running `rake routes`

### DIFF
--- a/ruby_02-web_applications_with_ruby/mix_master/3_implementing_songs.markdown
+++ b/ruby_02-web_applications_with_ruby/mix_master/3_implementing_songs.markdown
@@ -139,12 +139,16 @@ end
 Running `rake routes` will output this new path:
 
 ```
-         Prefix Verb URI Pattern                             Controller#Action
-new_artist_song GET  /artists/:artist_id/songs/new(.:format) songs#new
-        artists GET  /artists(.:format)                      artists#index
-                POST /artists(.:format)                      artists#create
-     new_artist GET  /artists/new(.:format)                  artists#new
-         artist GET  /artists/:id(.:format)                  artists#show
+         Prefix Verb    URI Pattern                             Controller#Action
+new_artist_song GET     /artists/:artist_id/songs/new(.:format) songs#new
+        artists GET     /artists(.:format)                      artists#index
+                POST    /artists(.:format)                      artists#create
+     new_artist GET     /artists/new(.:format)                  artists#new
+    edit_artist GET     /artists/:id/edit(.:format)             artists#edit
+         artist GET     /artists/:id(.:format)                  artists#show
+                PATCH   /artists/:id(.:format)                  artists#update
+                PUT     /artists/:id(.:format)                  artists#update
+                DELETE  /artists/:id(.:format)                  artists#destroy
 ```
 
 Take a look at that first line. `'/artists/:artist_id/songs/new'` is the path we want. The prefix is `new_artist_song` which is what we specified in our view. 


### PR DESCRIPTION
Because the end of iteration 2 asks for the tests **and** functionality to be implemented for the remaining RESTful routes, the expected output of running `rake routes` here should include all of those routes, not just the few that were created using `only` in the earlier part of that iteration.