### PR TITLE
Remove `only` from `resources :artists`

### DIFF
--- a/ruby_02-web_applications_with_ruby/mix_master/3_implementing_songs.markdown
+++ b/ruby_02-web_applications_with_ruby/mix_master/3_implementing_songs.markdown
@@ -363,7 +363,7 @@ Ok, we have an `undefined method 'song_path'`. We're trying to `redirect_to song
 
 ```ruby
 Rails.application.routes.draw do
-  resources :artists, only: [:index, :new, :create, :show] do 
+  resources :artists 
     resources :songs, only: [:new, :create]
   end
 


### PR DESCRIPTION
Remove the `only` section from line 366 to reflect what is actually expected after having completed iteration 2, where functionality for these routes was added.