### PR TITLE
Update feature_testing_in_sinatra_with_capybara.markdown

### DIFF
--- a/ruby_02-web_applications_with_ruby/outlines/feature_testing_in_sinatra_with_capybara.markdown
+++ b/ruby_02-web_applications_with_ruby/outlines/feature_testing_in_sinatra_with_capybara.markdown
@@ -32,7 +32,7 @@ ENV['TASK_MANAGER_ENV'] ||= 'test'
 
 require File.expand_path("../../config/environment", __FILE__)
 require 'minitest/autorun'
-require 'capybara'
+require 'capybara/DSL'
 
 module TestHelpers
   def teardown


### PR DESCRIPTION
Fixed line 35 from `require 'capybara'` to `require 'capybara/DSL'`