### PR TITLE
Fix ruby code styling for has_many association

### DIFF
--- a/ruby_02-web_applications_with_ruby/outlines/intro_to_active_record_in_sinatra.markdown
+++ b/ruby_02-web_applications_with_ruby/outlines/intro_to_active_record_in_sinatra.markdown
@@ -351,6 +351,7 @@ Film.find_by(title: "The Lion King").update_attributes(genre_id: 1)
 ```
 
 The better way to associate data is to do it upon creation:
+
 ```ruby
 animation = Genre.find_by(name: "Animation")
 animation.films.create(title: "The Lion King", year: 1994, box_office_sales: 422783777)


### PR DESCRIPTION

<img width="994" alt="ruby why u no work" src="https://cloud.githubusercontent.com/assets/19230981/20768425/29399f04-b6fb-11e6-8f4e-37ae17dbefae.png">
Ruby code syntax isn't showing up properly on line 354.  Seems like a blank line might be necessary above the '```ruby` for it to work.