### PR TITLE
Update websockets_workshop.markdown

### DIFF
--- a/ruby_04-apis_and_scalability/websockets_workshop.markdown
+++ b/ruby_04-apis_and_scalability/websockets_workshop.markdown
@@ -436,9 +436,9 @@ Now, let's swap out that `console.log` and send some information back to the ser
 // client.js
 var buttons = document.querySelectorAll('#choices button');
 
-for (var i = 0; i < buttons.length; i++) {
-  buttons[i].addEventListener('click', function () {
-    socket.send('voteCast', this.innerText);
+for (let i = 0; i < buttons.length; i++) {
+  buttons[i].addEventListener('click', (e) => {
+    socket.send('voteCast', e.target.innerText);
   });
 }
 ```


### PR DESCRIPTION
fix error with sending votecast on line 439.  refactor function to use arrow-function syntax and use e.target instead of this.innertext.