### PR TITLE
Update full_stack_integration_testing_with_selenium.markdown

### DIFF
--- a/ruby_04-apis_and_scalability/full_stack_integration_testing_with_selenium.markdown
+++ b/ruby_04-apis_and_scalability/full_stack_integration_testing_with_selenium.markdown
@@ -50,7 +50,7 @@ rake db:setup
 Additionally, go ahead and add the Selenium gem to your Gemfile:
 
 ```
-gem 'selenium-webdriver'
+gem 'selenium-webdriver', '~> 2.53.4'
 ```
 
 __Discussion: Browser-based WebDrivers vs. Rack::Test Driver and DB Test Transactions__


### PR DESCRIPTION
@Carmer 

I found out that the latest selenium-webdriver, v. 3, is basically brand new at this point and does not work with Firefox v 46. Instead, I had to use gem 'selenium-webdriver', '~> 2.53.4' and then my test opened firefox and ran as described in the rest of the tutorial.